### PR TITLE
Cleanup naming replaces user for users, everything else is in the plural...

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Currently, the following are supported:
 * Notifications: 25%
 * Likes: 0 %
 * Group memberships: 0 %
-* Relationships: 0 %
+* Relationships: 100 %
 * Suggestion: 0 %
 * Threads: 100 %
 * Subscriptions: 0 %
@@ -128,6 +128,7 @@ Apache Software License 2.0: http://www.apache.org/licenses/LICENSE-2.0
 
 Changelog
 =========
+* **Version 0.2.6**: Users replacing User. Added support for relationships by @webmutation
 * **Version 0.2.5**: Added support for threads by @tbenade
 * **Version 0.2.4**: Added support for likes by @tbenade
 * **Version 0.2.3**: Added support for retrieving message attachments by @willeeklund, internal plumbing changes by @tbenade

--- a/examples/relationships.js
+++ b/examples/relationships.js
@@ -1,0 +1,15 @@
+// This example show how to get relationships from current user and using params from other users as well
+// To get the relationships from a different user than current use params: {user_id:"USER_ID"}
+// To create relationships from current user to a new user, set one of the types of relationship as param
+// client.relationships.create({params},function(error, data) {
+// {subordinate | superior | colleague:"E-MAIL_OF Subordinate, Superior or Colleague "}
+
+var YammerAPIClient = require('../lib/api.js'),
+    client = new YammerAPIClient({token:"-->>ADD HERE YOUR OAUTH TOKEN<<--"});
+
+client.relationships.get(function(error, data) {
+    if(error)
+        console.log("There was an error retrieving the data");
+    else
+        console.log(data);
+});

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,10 +5,11 @@ var https = require('https'),
 // API modules
 var YammerMessagesAPI = require('./messages'),
     YammerTopicsAPI = require('./topics'),
-    YammerUserAPI = require('./user'),
+    YammerUsersAPI = require('./users'),
     YammerGroupsAPI = require('./groups');
     YammerNotificationsAPI = require('./notifications');
     YammerThreadsAPI = require('./threads');
+    YammerRelationshipsAPI = require('./relationships');
 
 module.exports = YammerAPIClient;
 
@@ -18,8 +19,9 @@ function YammerAPIClient(config) {
     // build the API with all the different components
     this.messages = new YammerMessagesAPI(config);
     this.topics = new YammerTopicsAPI(config);
-    this.users = new YammerUserAPI(config);
+    this.users = new YammerUsersAPI(config);
     this.groups = new YammerGroupsAPI(config);
     this.notifications = new YammerNotificationsAPI(config);
     this.threads = new YammerThreadsAPI(config);
+    this.relationships = new YammerRelationshipsAPI(config);
 }

--- a/lib/groups.js
+++ b/lib/groups.js
@@ -28,5 +28,5 @@ YammerAPI.addMethods({
 	delete: {
 		api: function(id) { return("/groups/" + id + ".json"); },
 		method: "delete"
-	},
+	}
 }, YammerGroupsAPI);

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -1,0 +1,24 @@
+var util = require('util'),
+    YammerAPI = require('./base');
+
+module.exports = YammerRelationshipsAPI;
+
+function YammerRelationshipsAPI(config) {
+    YammerAPI.call(this, config);
+}
+util.inherits(YammerRelationshipsAPI, YammerAPI);
+
+YammerAPI.addMethods({
+    get: {
+        api: "/relationships.json",
+        method: "get"
+    },
+    create: {
+        api: "/relationships.json",
+        method: "post"
+    },
+    delete: {
+        api: function(id) { return("/relationships/" + id + ".json"); },
+        method: "delete"
+    }
+}, YammerRelationshipsAPI);

--- a/lib/users.js
+++ b/lib/users.js
@@ -2,12 +2,12 @@ var util = require('util'),
 	assert = require('assert'),
     YammerAPI = require('./base');
 
-module.exports = YammerUserAPI;
+module.exports = YammerUsersAPI;
 
-function YammerUserAPI(config) {
+function YammerUsersAPI(config) {
     YammerAPI.call(this, config);
 }
-util.inherits(YammerUserAPI, YammerAPI);
+util.inherits(YammerUsersAPI, YammerAPI);
 
 YammerAPI.addMethods({ 
     list: {
@@ -38,8 +38,8 @@ YammerAPI.addMethods({
         api: "/users/current.json",
         method: "get"
     }
-}, YammerUserAPI);
+}, YammerUsersAPI);
 
-YammerUserAPI.prototype.by_email = function(email, callback) {      
+YammerUsersAPI.prototype.by_email = function(email, callback) {
     this.doGet(this.baseUrl + '/users/by_email.json', { "email": email }, callback);    
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yammer-rest-api-client",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": "Oscar Renalias <oscar@renalias.net> (http://www.renalias.net)",
   "description": "A node.js client for Yammer's RESTful API",
   "main": "./lib/api.js",

--- a/test/test/archived/user.js
+++ b/test/test/archived/user.js
@@ -1,8 +1,8 @@
-var YammerUserAPI = require('../lib/user.js'),
+var YammerUsersAPI = require('../lib/users.js'),
 	vows = require('vows'),
 	assert = require('assert'),
 	config = require('./helper/testconfig'),
-	userClient = new YammerUserAPI(config);
+	userClient = new YammerUsersAPI(config);
 
 vows.describe('Yammer users API').addBatch({
 	'when requesting all users': {


### PR DESCRIPTION
... and follows the Yammer naming convention.

Added Relationships API
Added Sample for Relationships
Updated Version and Readme
